### PR TITLE
update zarr requirement to 2.8.0

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -15,7 +15,7 @@ dependencies:
   - python == 3.7.9
   - scikit-image
   - pytest
-  - zarr >= 2.4.0
+  - zarr >= 2.8.0
   - pip
   - pandas
   - tabulate


### PR DESCRIPTION
This PR fixes reading of zarr-python data with xtensor-zarr by updating the install zarr version to one that uses the 'dimension_separator' metadata key.